### PR TITLE
Allow Postgis functions in datastore_search_sql API call

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,13 @@ Changelog
 
 .. towncrier release notes start
 
+v.2.9.11-civity.5 TBD
+===================
+
+Minor changes
+-------------
+- Added 4 additional PostGIS functions to the [allowed functions](ckanext/datastore/allowed_functions.txt) of the DataStore plugin: `st_area`, `st_distance`, `st_length`, and `st_perimeter`. (`CIVDEV-1472 <https://civity.atlassian.net/browse/CIVDEV-1472>`_)
+
 v.2.9.11-civity.4 2025-01-13
 ===================
 

--- a/ckanext/datastore/allowed_functions.txt
+++ b/ckanext/datastore/allowed_functions.txt
@@ -234,6 +234,7 @@ sind
 slope
 split_part
 sqrt
+st_area
 st_asewkt
 st_asgeojson
 st_asgml
@@ -244,12 +245,15 @@ st_closestpoint
 st_contains
 st_covers
 st_dfullywithin
+st_distance
 st_dwithin
 st_geomfromewkt
 st_geomfromgeojson
 st_geomfromgml
 st_geomfromtext
 st_intersects
+st_length
+st_perimeter
 st_setsrid
 st_transform
 st_union


### PR DESCRIPTION
Adds 4 additional postgis functions to the allowed functions of the DataStore.